### PR TITLE
fixed bool operator for IconAtlas

### DIFF
--- a/include/specter/Icon.hpp
+++ b/include/specter/Icon.hpp
@@ -42,7 +42,7 @@ class IconAtlas
     }
 public:
     IconAtlas() = default;
-    operator bool() const {return m_tex != nullptr;}
+    operator bool() const {return m_tex;}
     void initializeAtlas(const boo::ObjToken<boo::ITextureS>& tex)
     {
         m_tex = tex;


### PR DESCRIPTION
Hi,
I tried to compile urde yesterday and had an error about this line, saying both operands can't be compared. Looking at the commit history I don't understand why it did not appear earlier, but this seems to fix the issue; As m_tex can return a boolean I guess it is the expected behaviour ?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/specter/1)
<!-- Reviewable:end -->
