### PR TITLE
Toolbar: Correct log module name

### DIFF
--- a/lib/Toolbar.cpp
+++ b/lib/Toolbar.cpp
@@ -6,7 +6,7 @@
 #define TOOLBAR_PADDING 10
 
 namespace specter {
-static logvisor::Module Log("specter::Space");
+static logvisor::Module Log("specter::Toolbar");
 
 static const zeus::RGBA32 Tex[] = {{{255, 255, 255, 64}}, {{255, 255, 255, 64}}, {{0, 0, 0, 64}}, {{0, 0, 0, 64}}};
 


### PR DESCRIPTION
This isn't the space-related code, so we can amend this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/specter/7)
<!-- Reviewable:end -->
