### PR TITLE
FileBrowser: Move constructor definition into cpp file

### DIFF
--- a/include/specter/FileBrowser.hpp
+++ b/include/specter/FileBrowser.hpp
@@ -226,8 +226,7 @@ private:
 
 public:
   FileBrowser(ViewResources& res, View& parentView, std::string_view title, Type type,
-              std::function<void(bool, hecl::SystemStringView)> returnFunc)
-  : FileBrowser(res, parentView, title, type, hecl::GetcwdStr(), returnFunc) {}
+              std::function<void(bool, hecl::SystemStringView)> returnFunc);
   FileBrowser(ViewResources& res, View& parentView, std::string_view title, Type type,
               hecl::SystemStringView initialPath, std::function<void(bool, hecl::SystemStringView)> returnFunc);
   ~FileBrowser() override;

--- a/lib/FileBrowser.cpp
+++ b/lib/FileBrowser.cpp
@@ -44,6 +44,10 @@ std::vector<hecl::SystemString> FileBrowser::PathComponents(hecl::SystemStringVi
 }
 
 FileBrowser::FileBrowser(ViewResources& res, View& parentView, std::string_view title, Type type,
+                         std::function<void(bool, hecl::SystemStringView)> returnFunc)
+: FileBrowser(res, parentView, title, type, hecl::GetcwdStr(), std::move(returnFunc)) {}
+
+FileBrowser::FileBrowser(ViewResources& res, View& parentView, std::string_view title, Type type,
                          hecl::SystemStringView initialPath,
                          std::function<void(bool, hecl::SystemStringView)> returnFunc)
 : ModalWindow(res, parentView,


### PR DESCRIPTION
Avoids requiring hecl.hpp to be included within the header. While we're at it, we can also std::move the returnFunc into the other constructor, potentially avoiding an internal heap allocation (in cases where std::function would need to allocate).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/specter/12)
<!-- Reviewable:end -->
