### PR TITLE
FontCache: Make filters non-allocating

### DIFF
--- a/include/specter/FontCache.hpp
+++ b/include/specter/FontCache.hpp
@@ -5,7 +5,6 @@
 
 #include <cstddef>
 #include <cstdint>
-#include <functional>
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -66,7 +65,7 @@ public:
   }
 };
 
-using FCharFilter = std::pair<std::string, std::function<bool(uint32_t)>>;
+using FCharFilter = std::pair<std::string_view, bool (*)(uint32_t)>;
 
 class FontAtlas {
   FT_Face m_face;

--- a/include/specter/FontCache.hpp
+++ b/include/specter/FontCache.hpp
@@ -176,6 +176,8 @@ class FontCache {
 
 public:
   FontCache(const hecl::Runtime::FileStoreManager& fileMgr);
+  ~FontCache();
+
   FontCache(const FontCache& other) = delete;
   FontCache& operator=(const FontCache& other) = delete;
 

--- a/lib/FontCache.cpp
+++ b/lib/FontCache.cpp
@@ -613,6 +613,8 @@ FontCache::FontCache(const hecl::Runtime::FileStoreManager& fileMgr)
   hecl::MakeDir(m_cacheRoot.c_str());
 }
 
+FontCache::~FontCache() = default;
+
 FontTag FontCache::prepCustomFont(std::string_view name, FT_Face face, FCharFilter filter, bool subpixel, float points,
                                   uint32_t dpi) {
   /* Quick validation */

--- a/lib/FontCache.cpp
+++ b/lib/FontCache.cpp
@@ -43,15 +43,16 @@ extern "C" const FT_Driver_ClassRec tt_driver_class;
 namespace specter {
 static logvisor::Module Log("specter::FontCache");
 
-const FCharFilter AllCharFilter = std::make_pair("all-glyphs", [](uint32_t) -> bool { return true; });
+const FCharFilter AllCharFilter{"all-glyphs", [](uint32_t) { return true; }};
 
-const FCharFilter LatinCharFilter =
-    std::make_pair("latin-glyphs", [](uint32_t c) -> bool { return c <= 0xff || ((c - 0x2200) <= (0x23FF - 0x2200)); });
+const FCharFilter LatinCharFilter{"latin-glyphs",
+                                  [](uint32_t c) { return c <= 0xff || (c - 0x2200) <= (0x23FF - 0x2200); }};
 
-const FCharFilter LatinAndJapaneseCharFilter = std::make_pair("latin-and-jp-glyphs", [](uint32_t c) -> bool {
-  return LatinCharFilter.second(c) || ((c - 0x2E00) <= (0x30FF - 0x2E00)) || ((c - 0x4E00) <= (0x9FFF - 0x4E00)) ||
-         ((c - 0xFF00) <= (0xFFEF - 0xFF00));
-});
+const FCharFilter LatinAndJapaneseCharFilter{"latin-and-jp-glyphs", [](uint32_t c) {
+                                               return LatinCharFilter.second(c) || (c - 0x2E00) <= (0x30FF - 0x2E00) ||
+                                                      (c - 0x4E00) <= (0x9FFF - 0x4E00) ||
+                                                      (c - 0xFF00) <= (0xFFEF - 0xFF00);
+                                             }};
 
 FontTag::FontTag(std::string_view name, bool subpixel, float points, uint32_t dpi) {
   XXH64_state_t st;
@@ -628,10 +629,11 @@ FontTag FontCache::prepCustomFont(std::string_view name, FT_Face face, FCharFilt
   FT_Set_Char_Size(face, 0, points * 64.0, 0, dpi);
 
   /* Make tag and search for cached version */
-  FontTag tag(std::string(name) + '_' + filter.first, subpixel, points, dpi);
-  auto search = m_cachedAtlases.find(tag);
-  if (search != m_cachedAtlases.end())
+  const FontTag tag(std::string(name).append(1, '_').append(filter.first), subpixel, points, dpi);
+  const auto search = m_cachedAtlases.find(tag);
+  if (search != m_cachedAtlases.end()) {
     return tag;
+  }
 
   /* Now check filesystem cache */
   hecl::SystemString cachePath = m_cacheRoot + _SYS_STR('/') + fmt::format(fmt(_SYS_STR("{}")), tag.hash());


### PR DESCRIPTION
Avoids the creation of three allocating static constructors that run during program start.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/specter/13)
<!-- Reviewable:end -->
