### PR TITLE
General: Use emplace_back's return value where applicable

### DIFF
--- a/lib/FileBrowser.cpp
+++ b/lib/FileBrowser.cpp
@@ -334,8 +334,7 @@ void FileBrowser::FileListingDataBind::updateListing(const hecl::DirectoryEnumer
   m_entries.reserve(dEnum.size());
 
   for (const hecl::DirectoryEnumerator::Entry& d : dEnum) {
-    m_entries.emplace_back();
-    Entry& ent = m_entries.back();
+    Entry& ent = m_entries.emplace_back();
     ent.m_path = d.m_path;
     hecl::SystemUTF8Conv nameUtf8(d.m_name);
     ent.m_name = nameUtf8.str();

--- a/lib/FontCache.cpp
+++ b/lib/FontCache.cpp
@@ -307,13 +307,10 @@ FontAtlas::FontAtlas(FT_Face face, uint32_t dpi, bool subpixel, FCharFilter& fil
         charcode = FT_Get_Next_Char(face, charcode, &gindex);
         continue;
       }
+
       FT_Load_Glyph(face, gindex, FT_LOAD_RENDER | baseFlags);
       FT_UInt width, height;
       GridFitGlyph(face->glyph, width, height);
-      m_glyphLookup[charcode] = m_glyphs.size();
-      m_glyphs.emplace_back();
-      Glyph& g = m_glyphs.back();
-
       if (curLineWidth + width + 1 > TEXMAP_DIM) {
         totalHeight += curLineHeight + 1;
         curLineHeight = 0;
@@ -328,6 +325,8 @@ FontAtlas::FontAtlas(FT_Face face, uint32_t dpi, bool subpixel, FCharFilter& fil
         curLineWidth = 1;
       }
 
+      m_glyphLookup.insert_or_assign(charcode, m_glyphs.size());
+      Glyph& g = m_glyphs.emplace_back();
       g.m_unicodePoint = charcode;
       g.m_glyphIdx = gindex;
       g.m_layerIdx = m_fullTexmapLayers;
@@ -369,13 +368,10 @@ FontAtlas::FontAtlas(FT_Face face, uint32_t dpi, bool subpixel, FCharFilter& fil
         charcode = FT_Get_Next_Char(face, charcode, &gindex);
         continue;
       }
+
       FT_Load_Glyph(face, gindex, FT_LOAD_RENDER | baseFlags);
       FT_UInt width, height;
       GridFitGlyph(face->glyph, width, height);
-      m_glyphLookup[charcode] = m_glyphs.size();
-      m_glyphs.emplace_back();
-      Glyph& g = m_glyphs.back();
-
       if (curLineWidth + width + 1 > TEXMAP_DIM) {
         totalHeight += curLineHeight + 1;
         curLineHeight = 0;
@@ -390,6 +386,8 @@ FontAtlas::FontAtlas(FT_Face face, uint32_t dpi, bool subpixel, FCharFilter& fil
         curLineWidth = 1;
       }
 
+      m_glyphLookup.insert_or_assign(charcode, m_glyphs.size());
+      Glyph& g = m_glyphs.emplace_back();
       g.m_unicodePoint = charcode;
       g.m_glyphIdx = gindex;
       g.m_layerIdx = m_fullTexmapLayers;
@@ -468,13 +466,10 @@ FontAtlas::FontAtlas(FT_Face face, uint32_t dpi, bool subpixel, FCharFilter& fil
         charcode = FT_Get_Next_Char(face, charcode, &gindex);
         continue;
       }
+
       FT_Load_Glyph(face, gindex, baseFlags);
       FT_UInt width, height;
       GridFitGlyph(face->glyph, width, height);
-      m_glyphLookup[charcode] = m_glyphs.size();
-      m_glyphs.emplace_back();
-      Glyph& g = m_glyphs.back();
-
       if (curLineWidth + width + 1 > TEXMAP_DIM) {
         totalHeight += curLineHeight + 1;
         curLineHeight = 0;
@@ -489,6 +484,8 @@ FontAtlas::FontAtlas(FT_Face face, uint32_t dpi, bool subpixel, FCharFilter& fil
         curLineWidth = 1;
       }
 
+      m_glyphLookup.insert_or_assign(charcode, m_glyphs.size());
+      Glyph& g = m_glyphs.emplace_back();
       g.m_unicodePoint = charcode;
       g.m_glyphIdx = gindex;
       g.m_layerIdx = m_fullTexmapLayers;
@@ -530,13 +527,10 @@ FontAtlas::FontAtlas(FT_Face face, uint32_t dpi, bool subpixel, FCharFilter& fil
         charcode = FT_Get_Next_Char(face, charcode, &gindex);
         continue;
       }
+
       FT_Load_Glyph(face, gindex, baseFlags);
       FT_UInt width, height;
       GridFitGlyph(face->glyph, width, height);
-      m_glyphLookup[charcode] = m_glyphs.size();
-      m_glyphs.emplace_back();
-      Glyph& g = m_glyphs.back();
-
       if (curLineWidth + width + 1 > TEXMAP_DIM) {
         totalHeight += curLineHeight + 1;
         curLineHeight = 0;
@@ -551,6 +545,8 @@ FontAtlas::FontAtlas(FT_Face face, uint32_t dpi, bool subpixel, FCharFilter& fil
         curLineWidth = 1;
       }
 
+      m_glyphLookup.insert_or_assign(charcode, m_glyphs.size());
+      Glyph& g = m_glyphs.emplace_back();
       g.m_unicodePoint = charcode;
       g.m_glyphIdx = gindex;
       g.m_layerIdx = m_fullTexmapLayers;

--- a/lib/Menu.cpp
+++ b/lib/Menu.cpp
@@ -55,9 +55,7 @@ void Menu::reset(IMenuNode* rootNode) {
     for (size_t i = 0; i < subCount; ++i) {
       IMenuNode* node = rootNode->subNode(i);
       const std::string* nodeText = node->text();
-
-      m_items.emplace_back();
-      ViewChild<std::unique_ptr<ItemView>>& item = m_items.back();
+      ViewChild<std::unique_ptr<ItemView>>& item = m_items.emplace_back();
 
       if (nodeText) {
         item.m_view.reset(new ItemView(res, *this, *nodeText, i, node));

--- a/lib/Table.cpp
+++ b/lib/Table.cpp
@@ -525,9 +525,7 @@ bool Table::CellView::reset(size_t c, size_t r) {
 
 std::vector<Table::ColumnPool>& Table::ensureCellPools(size_t rows, size_t cols, ViewResources& res) {
   if (m_cellPools.size() < cols) {
-    m_cellPools.reserve(cols);
-    for (size_t i = m_cellPools.size(); i < cols; ++i)
-      m_cellPools.emplace_back();
+    m_cellPools.resize(cols);
     m_ensuredRows = 0;
   }
   if (m_ensuredRows < rows) {
@@ -569,9 +567,7 @@ void Table::_updateData() {
   if (newViewChildren) {
     m_headerViews.clear();
     m_cellPools.clear();
-    m_headerViews.reserve(m_columns);
-    for (size_t c = 0; c < m_columns; ++c)
-      m_headerViews.emplace_back();
+    m_headerViews.resize(m_columns);
     m_ensuredRows = 0;
   }
   ensureCellPools(m_rows, m_columns, res);

--- a/lib/Toolbar.cpp
+++ b/lib/Toolbar.cpp
@@ -115,11 +115,13 @@ void Toolbar::setVerticalVerts(int height) {
 }
 
 void Toolbar::push_back(View* v, unsigned unit) {
-  if (unit >= m_units)
+  if (unit >= m_units) {
     Log.report(logvisor::Fatal, fmt("unit {} out of range {}"), unit, m_units);
-  std::vector<ViewChild<View*>>& u = m_children[unit];
-  u.emplace_back();
-  u.back().m_view = v;
+  }
+
+  std::vector<ViewChild<View*>>& children = m_children[unit];
+  auto& child = children.emplace_back();
+  child.m_view = v;
 }
 
 void Toolbar::resized(const boo::SWindowRect& root, const boo::SWindowRect& sub) {

--- a/lib/Toolbar.cpp
+++ b/lib/Toolbar.cpp
@@ -20,11 +20,9 @@ void Toolbar::Resources::init(boo::IGraphicsDataFactory::Context& ctx, const ITh
 Toolbar::Toolbar(ViewResources& res, View& parentView, Position tbPos, unsigned units)
 : View(res, parentView)
 , m_units(units)
+, m_children(units)
 , m_nomGauge(res.pixelFactor() * SPECTER_TOOLBAR_GAUGE * units)
 , m_padding(res.pixelFactor() * TOOLBAR_PADDING) {
-  m_children.reserve(units);
-  for (unsigned u = 0; u < units; ++u)
-    m_children.emplace_back();
   commitResources(res, [&](boo::IGraphicsDataFactory::Context& ctx) -> bool {
     buildResources(ctx, res);
     m_tbBlockBuf = res.m_viewRes.m_bufPool.allocateBlock(res.m_factory);


### PR DESCRIPTION
`emplace_back()` returns a reference to the emplaced element, so we can use that instead of querying right after the emplacement.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/specter/14)
<!-- Reviewable:end -->
