### PR TITLE
General: Remove unused file-scope variables

### DIFF
--- a/lib/FileBrowser.cpp
+++ b/lib/FileBrowser.cpp
@@ -7,11 +7,8 @@
 #include "specter/TextField.hpp"
 
 #include <hecl/hecl.hpp>
-#include <logvisor/logvisor.hpp>
 
 namespace specter {
-static logvisor::Module Log("specter::FileBrowser");
-
 #define BROWSER_MARGIN 8
 #define BROWSER_MIN_WIDTH 600
 #define BROWSER_MIN_HEIGHT 300

--- a/lib/RootView.cpp
+++ b/lib/RootView.cpp
@@ -9,10 +9,8 @@
 #include "specter/ViewResources.hpp"
 
 #include <boo/graphicsdev/IGraphicsCommandQueue.hpp>
-#include <logvisor/logvisor.hpp>
 
 namespace specter {
-static logvisor::Module Log("specter::RootView");
 
 RootView::RootView(IViewManager& viewMan, ViewResources& res, boo::IWindow* window)
 : View(res), m_window(window), m_viewMan(viewMan), m_viewRes(&res), m_events(*this) {

--- a/lib/Space.cpp
+++ b/lib/Space.cpp
@@ -5,11 +5,8 @@
 #include "specter/ViewResources.hpp"
 
 #include <boo/graphicsdev/IGraphicsCommandQueue.hpp>
-#include <logvisor/logvisor.hpp>
 
 namespace specter {
-static logvisor::Module Log("specter::Space");
-
 #define TRIANGLE_DIM 12
 #define TRIANGLE_DIM1 10
 #define TRIANGLE_DIM2 8

--- a/lib/View.cpp
+++ b/lib/View.cpp
@@ -5,11 +5,8 @@
 
 #include <boo/System.hpp>
 #include <hecl/Pipeline.hpp>
-#include <logvisor/logvisor.hpp>
 
 namespace specter {
-static logvisor::Module Log("specter::View");
-
 zeus::CMatrix4f g_PlatformMatrix;
 
 void View::Resources::init(boo::IGraphicsDataFactory::Context& ctx, const IThemeData& theme) {


### PR DESCRIPTION
Removes unused logvisor modules. This also allows removing some inclusions. Silences a few unused variable warnings as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/specter/15)
<!-- Reviewable:end -->
