### PR TITLE
FontCache: Be explicit about athena's SeekOrigin type

### DIFF
--- a/lib/FontCache.cpp
+++ b/lib/FontCache.cpp
@@ -148,7 +148,7 @@ void FontAtlas::buildKernTable(FT_Face face) {
       TT_KernHead kernHead;
       kernHead.read(r);
       if (kernHead.coverage >> 8 != 0) {
-        r.seek(kernHead.length - 6, athena::Current);
+        r.seek(kernHead.length - 6, athena::SeekOrigin::Current);
         continue;
       }
 
@@ -199,7 +199,7 @@ static void WriteCompressed(athena::io::FileWriter& writer, const atUint8* data,
     writer.writeUBytes(compBuf, ZLIB_BUF_SZ - z.avail_out);
   }
 
-  writer.seek(adlerPos, athena::Begin);
+  writer.seek(adlerPos, athena::SeekOrigin::Begin);
   writer.writeUint32Big(z.adler);
 
   deflateEnd(&z);


### PR DESCRIPTION
Allows this code to still function properly if the enum is turned into an enum class.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/axiodl/specter/16)
<!-- Reviewable:end -->
